### PR TITLE
Update express-basic-auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "express-basic-auth": "^0.2.3",
+    "express-basic-auth": "^1.0.0",
     "node-ip": "^0.1.2",
     "shelljs": "^0.7.6",
     "sqlite3": "^3.1.8",


### PR DESCRIPTION
I noticed that you are using an old version of `express-basic-auth`. Version 1.0.0 is fully compatible with the one you are using now, so using it will enable you to get the latest updates, features and bugfixes without having to change any code.